### PR TITLE
Infra/fix ci multi image build with GHCR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,7 @@ name: CI
 
 on:
   push:
-    branches:
-      - master
+    branches: ['master', 'infra/fix_CI_multi_image_build']
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,15 @@ jobs:
             include:
               - dockerfile: ./Services/GeometryGeneratorNonSampled/Dockerfile
                 image: ghcr.io/TsvetislavRangelov/mesher-geometry-generator-nonsampled
+                working-directory: ./Services/GeometryGeneratorNonSampled
+
               - dockerfile: ./Services/ApiGateway/Dockerfile
                 image: ghcr.io/TsvetislavRangelov/mesher-apigw
+                working-directory: ./Services/ApiGateway
+
               - dockerfile: ./mesher-client/Dockerfile
                 image: ghcr.io/TsvetislavRangelov/mesher-web-client
+                working-directory: ./mesher-client
     permissions:
       contents: read
       packages: write 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         name: Build and Push Mesher Images
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ./Services/ApiGateway
           file: ${{matrix.dockerfile}}
           push: true
           tags: ${{steps.meta.outputs.tags}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
 
               - dockerfile: ./mesher-client/Dockerfile
                 image: ghcr.io/TsvetislavRangelov/mesher-web-client
-                working-directory: ./mesher-client
+                working-directory: ./mesher-client 
     permissions:
       contents: read
       packages: write 
@@ -53,7 +53,7 @@ jobs:
         name: Build and Push Mesher Images
         uses: docker/build-push-action@v5
         with:
-          context: ./Services/ApiGateway
+          context: ${{matrix.working-directory}}
           file: ${{matrix.dockerfile}}
           push: true
           tags: ${{steps.meta.outputs.tags}}


### PR DESCRIPTION
The CI was failing due to the build context of docker being incorrect. Now, an environment variable to set the context dynamically is used for each service.